### PR TITLE
INTG-477 Ensure HTTPS is used to access MuleSoft Maven repositories

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14966,7 +14966,7 @@ async function build(secret_key, nexusUser, nexusPassword) {
     if (nexusUser && nexusPassword)
         generateMavenSettings(nexusUser, nexusPassword);
 
-    var build_command = 'mvn -B package --file pom.xml -X -Denv=local ';
+    var build_command = 'mvn -B package --file pom.xml -Denv=local ';
     if (secret_key)
         build_command += "-Dsecret.key=" + secret_key + " "
     const build = await exec(build_command);

--- a/dist/maven-settings.xml
+++ b/dist/maven-settings.xml
@@ -27,7 +27,7 @@
                 <repository>
                     <id>mulesoft-releases</id>
                     <name>MuleSoft Releases Repository</name>
-                    <url>http://repository.mulesoft.org/releases/</url>
+                    <url>https://repository.mulesoft.org/releases/</url>
                 </repository>
             </repositories>
             <pluginRepositories>
@@ -39,7 +39,7 @@
                 <pluginRepository>
                     <id>mulesoft-releases</id>
                     <name>MuleSoft Releases Repository</name>
-                    <url>http://repository.mulesoft.org/releases/</url>
+                    <url>https://repository.mulesoft.org/releases/</url>
                 </pluginRepository>
             </pluginRepositories>
         </profile>

--- a/src/maven.js
+++ b/src/maven.js
@@ -51,7 +51,7 @@ async function build(secret_key, nexusUser, nexusPassword) {
     if (nexusUser && nexusPassword)
         generateMavenSettings(nexusUser, nexusPassword);
 
-    var build_command = 'mvn -B package --file pom.xml -X -Denv=local ';
+    var build_command = 'mvn -B package --file pom.xml -Denv=local ';
     if (secret_key)
         build_command += "-Dsecret.key=" + secret_key + " "
     const build = await exec(build_command);

--- a/template/maven-settings.xml
+++ b/template/maven-settings.xml
@@ -27,7 +27,7 @@
                 <repository>
                     <id>mulesoft-releases</id>
                     <name>MuleSoft Releases Repository</name>
-                    <url>http://repository.mulesoft.org/releases/</url>
+                    <url>https://repository.mulesoft.org/releases/</url>
                 </repository>
             </repositories>
             <pluginRepositories>
@@ -39,7 +39,7 @@
                 <pluginRepository>
                     <id>mulesoft-releases</id>
                     <name>MuleSoft Releases Repository</name>
-                    <url>http://repository.mulesoft.org/releases/</url>
+                    <url>https://repository.mulesoft.org/releases/</url>
                 </pluginRepository>
             </pluginRepositories>
         </profile>


### PR DESCRIPTION
The image used by GitHub actions uses Maven 3.8.1. This version enforces HTTPS for all repository access and blocks the HTTP protocol. We need to update our repository configurations accordingly.